### PR TITLE
fix: API Stats return an object, not an array.

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -145,12 +145,10 @@ paths:
             application/json:
               schema:
                 type: object
-                title: AddonStatsListResponse
+                title: AddonStatsResponse
                 properties:
                   data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/AddonStats'
+                    $ref: '#/components/schemas/AddonStats'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         default:

--- a/sdk-configs/csharp-netcore.json
+++ b/sdk-configs/csharp-netcore.json
@@ -1,7 +1,7 @@
 {
   "packagePath": ".",
   "packageName": "Everyday.GmodStore.Sdk",
-  "packageVersion": "1.6.0",
+  "packageVersion": "1.6.1",
   "packageAuthors": "Everyday AS and contributors",
   "packageCompany": "Everyday AS",
   "packageDescription": "You can use this package to access GmodStore API endpoints, which can be used interact with GmodStore programmatically.",

--- a/sdk-configs/java.json
+++ b/sdk-configs/java.json
@@ -5,7 +5,7 @@
   "modelPackage": "no.everyday.gmodstore-sdk.model",
   "apiPackage": "no.everyday.gmodstore-sdk.api",
   "groupId": "no.everyday",
-  "artifactVersion": "1.5.0",
+  "artifactVersion": "1.5.1",
   "artifactId": "gmodstore-sdk",
   "artifactUrl": "https://github.com/everyday-as/gmodstore-java-sdk",
   "artifactDescription": "The GmodStore API Java SDK",

--- a/sdk-configs/javascript.json
+++ b/sdk-configs/javascript.json
@@ -1,7 +1,7 @@
 {
   "projectName": "gmodstore-sdk",
   "packageName": "gmodstore-sdk",
-  "projectVersion": "1.3.0",
+  "projectVersion": "1.3.1",
   "gitUserId": "everyday",
   "gitRepoId": "gmodstore-sdk",
   "invokerPackage": "Everyday/GmodStore/Sdk",

--- a/sdk-configs/python.json
+++ b/sdk-configs/python.json
@@ -1,7 +1,7 @@
 {
   "packageUrl": ".",
   "packageName": "gmodstore-sdk",
-  "packageVersion": "1.5.0",
+  "packageVersion": "1.5.1",
   "projectName": "GmodStore SDK",
   "gitUserId": "everyday-as",
   "gitRepoId": "gmodstore-python-sdk",


### PR DESCRIPTION
Current version of the PHP SDK fails on `GET /addons/{addon}/stats`, with `Invalid array '\Everyday\GmodStore\Sdk\Model\AddonStats[]'`.

The stats endpoint does not return an array, rather it returns an object.
This PR fixes the API schema, but makes no attempt to discern if any other data (such as tests) needs to be manually updated to match.

This PR has been tested by generating with OpenAPI Generator 5.4.0, `java -jar openapi-generator-cli-5.4.0.jar generate -i ./gmodstore-api-docs/openapi.yaml -g php -o joshpiper/gmodstore-sdk`, linked with composer's local path repository, and tested for function with the following code:
```php
<?php

require __DIR__ . "/vendor/autoload.php";

$x = \OpenAPI\Client\Configuration::getDefaultConfiguration()
	->setAccessToken("<token>");

$y = new \OpenAPI\Client\Api\AddonStatsApi(null, $x);
var_dump($y->getAddonStats("<addonId>")->getData());
```